### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/client/Lykke.Service.GoogleDriveUpload.Client/Lykke.Service.GoogleDriveUpload.Client.csproj
+++ b/client/Lykke.Service.GoogleDriveUpload.Client/Lykke.Service.GoogleDriveUpload.Client.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>https://github.com/LykkeCity/Lykke.Service.GoogleDriveUpload.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Lykke</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />

--- a/src/Lykke.Service.GoogleDriveUpload.AzureRepositories/Lykke.Service.GoogleDriveUpload.AzureRepositories.csproj
+++ b/src/Lykke.Service.GoogleDriveUpload.AzureRepositories/Lykke.Service.GoogleDriveUpload.AzureRepositories.csproj
@@ -5,7 +5,15 @@
     <AssemblyName>Lykke.Service.GoogleDriveUpload.AzureRepositories</AssemblyName>
     <RootNamespace>Lykke.Service.GoogleDriveUpload.AzureRepositories</RootNamespace>
     <Version>1.0.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Lykke.AzureStorage" Version="1.2.36" />

--- a/src/Lykke.Service.GoogleDriveUpload.Core/Lykke.Service.GoogleDriveUpload.Core.csproj
+++ b/src/Lykke.Service.GoogleDriveUpload.Core/Lykke.Service.GoogleDriveUpload.Core.csproj
@@ -5,7 +5,15 @@
     <AssemblyName>Lykke.Service.GoogleDriveUpload.Core</AssemblyName>
     <RootNamespace>Lykke.Service.GoogleDriveUpload.Core</RootNamespace>
     <Version>1.0.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Lykke.Common" Version="1.1.95" />

--- a/src/Lykke.Service.GoogleDriveUpload.Services/Lykke.Service.GoogleDriveUpload.Services.csproj
+++ b/src/Lykke.Service.GoogleDriveUpload.Services/Lykke.Service.GoogleDriveUpload.Services.csproj
@@ -5,7 +5,15 @@
     <AssemblyName>Lykke.Service.GoogleDriveUpload.Services</AssemblyName>
     <RootNamespace>Lykke.Service.GoogleDriveUpload.Services</RootNamespace>
     <Version>1.0.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="2.16.3" />

--- a/src/Lykke.Service.GoogleDriveUpload/Lykke.Service.GoogleDriveUpload.csproj
+++ b/src/Lykke.Service.GoogleDriveUpload/Lykke.Service.GoogleDriveUpload.csproj
@@ -6,7 +6,15 @@
     <Version>1.0.1</Version>
     <AssemblyName>Lykke.Service.GoogleDriveUpload</AssemblyName>
     <RootNamespace>Lykke.Service.GoogleDriveUpload</RootNamespace>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netcoreapp2.0\Lykke.Service.GoogleDriveUpload.xml</DocumentationFile>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
